### PR TITLE
Fix for 1) LAI/SAI aggregation bug for PFT and PC; 2) LULCC initializ…

### DIFF
--- a/main/LULCC/MOD_Lulcc_Initialize.F90
+++ b/main/LULCC/MOD_Lulcc_Initialize.F90
@@ -119,7 +119,7 @@ MODULE MOD_Lulcc_Initialize
    CALL deallocate_TimeVariables
 
    CALL initialize (casename,dir_landdata,dir_restart,&
-                    idate,year,greenwich)
+                    idate,year,greenwich,lulcc_call=.true.)
 
  END SUBROUTINE LulccInitialize
 

--- a/main/MOD_Thermal.F90
+++ b/main/MOD_Thermal.F90
@@ -903,7 +903,6 @@ IF (patchtype == 0) THEN
             rstfacsha_c(p) = rstfac_c(p)
 
          ELSE
-            tleaf_c(p,pc)     = forc_t
             laisun_c(p)       = 0.
             laisha_c(p)       = 0.
             ldew_rain_c(p,pc) = 0.
@@ -912,12 +911,6 @@ IF (patchtype == 0) THEN
             rootr_c(:,p)      = 0.
             rstfacsun_c(p)    = 0.
             rstfacsha_c(p)    = 0.
-            rst_c(p,pc)       = 2.0e4
-            assim_c(p,pc)     = 0.
-            respc_c(p,pc)     = 0.
-            fsenl_c(p,pc)     = 0.
-            fevpl_c(p,pc)     = 0.
-            etr_c(p,pc)       = 0.
 
             IF(DEF_USE_PLANTHYDRAULICS)THEN
                vegwp_c (:,p,pc)  = -2.5e4
@@ -925,6 +918,16 @@ IF (patchtype == 0) THEN
          ENDIF
 
       ENDDO
+      ! initialization
+      tleaf_c (:,pc) = forc_t  !???
+      rst_c   (:,pc) = 2.0e4
+      assim_c (:,pc) = 0.
+      respc_c (:,pc) = 0.
+      fsenl_c (:,pc) = 0.
+      fevpl_c (:,pc) = 0.
+      etr_c   (:,pc) = 0.
+      z0m_c   (:,pc) = (1.-fsno)*zlnd + fsno*zsno
+
 
       IF (lai+sai > 1e-6) THEN
 

--- a/mkinidata/MOD_Initialize.F90
+++ b/mkinidata/MOD_Initialize.F90
@@ -18,7 +18,7 @@ MODULE MOD_Initialize
 
 
    SUBROUTINE initialize (casename, dir_landdata, dir_restart, &
-         idate, lc_year, greenwich)
+         idate, lc_year, greenwich, lulcc_call)
 
       ! ======================================================================
       ! initialization routine for land surface model.
@@ -99,6 +99,7 @@ MODULE MOD_Initialize
       integer, intent(inout) :: idate(3)   ! year, julian day, seconds of the starting time
       integer, intent(in)    :: lc_year    ! year, land cover year
       logical, intent(in)    :: greenwich  ! true: greenwich time, false: local time
+      logical, optional, intent(in) :: lulcc_call   ! whether it is a lulcc CALL
 
       ! ------------------------ local variables -----------------------------
       real(r8) :: rlon, rlat
@@ -831,7 +832,7 @@ MODULE MOD_Initialize
       call check_TimeVariables ()
 #endif
 
-      IF (year == DEF_simulation_time%start_year) THEN
+      IF ( .not. present(lulcc_call) ) THEN
          ! only be called in runing MKINI, LULCC will be executed later
          CALL WRITE_TimeVariables (idate, lc_year, casename, dir_restart)
       ENDIF
@@ -846,7 +847,7 @@ MODULE MOD_Initialize
       ! --------------------------------------------------
       ! Deallocates memory for CoLM 1d [numpatch] variables
       ! --------------------------------------------------
-      IF (year == DEF_simulation_time%start_year) THEN
+      IF ( .not. present(lulcc_call) ) THEN
          ! only be called in runing MKINI, LULCC will be executed later
          CALL deallocate_TimeInvariants
          CALL deallocate_TimeVariables

--- a/mksrfdata/Aggregation_LAI.F90
+++ b/mksrfdata/Aggregation_LAI.F90
@@ -445,7 +445,9 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
                      IF (sumarea > 0) THEN
                         LAI_pfts(ip) = sum(lai_pft_one(p,:) * pct_pft_one(p,:) * area_one) / sumarea
                      ELSE
-                        LAI_pfts(ip) = LAI_patches(ipatch)
+                        ! 07/2023, yuan: bug may exist below
+                        !LAI_pfts(ip) = LAI_patches(ipatch)
+                        LAI_pfts(ip) = 0.
                      ENDIF
                   ENDDO
 #ifdef CROP
@@ -559,7 +561,9 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
                      IF (sumarea > 0) THEN
                         SAI_pfts(ip) = sum(sai_pft_one(p,:) * pct_pft_one(p,:) * area_one) / sumarea
                      ELSE
-                        SAI_pfts(ip) = SAI_patches(ipatch)
+                        ! 07/2023, yuan: bug may exist below
+                        !SAI_pfts(ip) = SAI_patches(ipatch)
+                        SAI_pfts(ip) = 0.
                      ENDIF
                   ENDDO
 #ifdef CROP
@@ -726,7 +730,9 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
                      IF (sumarea > 0) THEN
                         LAI_pcs(ipft,ipc) = sum(lai_pft_one(ipft,:) * pct_pft_one(ipft,:) * area_one) / sumarea
                      ELSE
-                        LAI_pcs(ipft,ipc) = LAI_patches(ipatch)
+                        ! 07/2023, yuan: bug may exist below
+                        !LAI_pcs(ipft,ipc) = LAI_patches(ipatch)
+                        LAI_pcs(ipft,ipc) = 0.
                      ENDIF
                   ENDDO
                ENDIF
@@ -816,7 +822,9 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
                      IF (sumarea > 0) THEN
                         SAI_pcs(ipft,ipc) = sum(sai_pft_one(ipft,:) * pct_pft_one(ipft,:) * area_one) / sumarea
                      ELSE
-                        SAI_pcs(ipft,ipc) = SAI_patches(ipatch)
+                        ! 07/2023, yuan: bug may exist below
+                        !SAI_pcs(ipft,ipc) = SAI_patches(ipatch)
+                        SAI_pcs(ipft,ipc) = 0.
                      ENDIF
                   ENDDO
                ENDIF

--- a/mksrfdata/Aggregation_PercentagesPFT.F90
+++ b/mksrfdata/Aggregation_PercentagesPFT.F90
@@ -1,10 +1,10 @@
 #include <define.h>
 
 SUBROUTINE Aggregation_PercentagesPFT (gland, dir_rawdata, dir_model_landdata, lc_year)
-   
+
    ! ----------------------------------------------------------------------
    ! Percentage of Plant Function Types
-   ! 
+   !
    ! Original from Hua Yuan's OpenMP version.
    !
    ! REVISIONS:


### PR DESCRIPTION
…ation

problem; 3) a PC initialization bug.

-fix(Aggregation_LAI.F90):
    set LAI/SAI=0 when sumarea=0.

-fix(MOD_Lulcc_Initialize.F90,MOD_Initialize.F90):
    add an optional parameter lulcc_call to distinguish mkini and lulcc
    mkini.

-fix(MOD_Thermal.F90):
    add initialization for some PC variables.