### PR TITLE
A complement for the previous fix to Change the input forcing time

### DIFF
--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -1030,7 +1030,7 @@ contains
          tstamp_LB(var_i)%sec = sec
 
          ! set time stamp (ststamp_LB)
-         if (sec <= 0) then
+         if (sec < 0) then
             tstamp_LB(var_i)%sec = 86400 + sec
             tstamp_LB(var_i)%day = day - 1
             if (tstamp_LB(var_i)%day == 0) then
@@ -1096,7 +1096,7 @@ contains
          tstamp_LB(var_i)%sec  = sec
 
          ! set time stamp (ststamp_LB)
-         if (sec <= 0) then
+         if (sec < 0) then
             tstamp_LB(var_i)%sec = 86400 + sec
             tstamp_LB(var_i)%day = day - 1
             if (tstamp_LB(var_i)%day == 0) then
@@ -1159,7 +1159,7 @@ contains
          tstamp_LB(var_i)%sec  = sec
 
          ! set time stamp (ststamp_LB)
-         if (sec <= 0) then
+         if (sec < 0) then
             tstamp_LB(var_i)%sec = 86400 + sec
             tstamp_LB(var_i)%day = day - 1
             if (tstamp_LB(var_i)%day == 0) then


### PR DESCRIPTION
from end to beginning style.

-mod(MOD_Forcing.F90):
    for function setstampLB, change the judgement:
      if (sec <=0 ) ==> if (sec < 0), don't adjust to the end style.
    NOTE: this modification may not have any effects, only for code
    consistency.