### PR TITLE
Only print warning for the first time-step for reference height less

### DIFF
--- a/main/MOD_LeafTemperature.F90
+++ b/main/MOD_LeafTemperature.F90
@@ -529,17 +529,20 @@ CONTAINS
 
          IF (hu <= htop+1) THEN
             hu_ = htop + 1.
-            write(6,*) 'Warning: the obs height of u less than htop+1, set it to htop+1.'
+            IF (taux == spval) & ! only print warning for the firt time-step
+               write(6,*) 'Warning: the obs height of u less than htop+1, set it to htop+1.'
          ENDIF
 
          IF (ht <= htop+1) THEN
             ht_ = htop + 1.
-            write(6,*) 'Warning: the obs height of t less than htop+1, set it to htop+1.'
+            IF (taux == spval) & ! only print warning for the firt time-step
+               write(6,*) 'Warning: the obs height of t less than htop+1, set it to htop+1.'
          ENDIF
 
          IF (hq <= htop+1) THEN
             hq_ = htop + 1.
-            write(6,*) 'Warning: the obs height of q less than htop+1, set it to htop+1.'
+            IF (taux == spval) & ! only print warning for the firt time-step
+               write(6,*) 'Warning: the obs height of q less than htop+1, set it to htop+1.'
          ENDIF
 
       ELSE ! relative height

--- a/main/MOD_LeafTemperaturePC.F90
+++ b/main/MOD_LeafTemperaturePC.F90
@@ -913,17 +913,20 @@ CONTAINS
 
          IF (hu <= htop_lay(toplay)+1) THEN
             hu_ = htop_lay(toplay) + 1.
-            write(6,*) 'Warning: the obs height of u less than htop+1, set it to htop+1.'
+            IF (taux == spval) & ! only print warning for the firt time-step
+               write(6,*) 'Warning: the obs height of u less than htop+1, set it to htop+1.'
          ENDIF
 
          IF (ht <= htop_lay(toplay)+1) THEN
             ht_ = htop_lay(toplay) + 1.
-            write(6,*) 'Warning: the obs height of t less than htop+1, set it to htop+1.'
+            IF (taux == spval) & ! only print warning for the firt time-step
+               write(6,*) 'Warning: the obs height of t less than htop+1, set it to htop+1.'
          ENDIF
 
          IF (hq <= htop_lay(toplay)+1) THEN
             hq_ = htop_lay(toplay) + 1.
-            write(6,*) 'Warning: the obs height of q less than htop+1, set it to htop+1.'
+            IF (taux == spval) & ! only print warning for the firt time-step
+               write(6,*) 'Warning: the obs height of q less than htop+1, set it to htop+1.'
          ENDIF
 
       ELSE ! relative height

--- a/main/URBAN/MOD_Urban_Flux.F90
+++ b/main/URBAN/MOD_Urban_Flux.F90
@@ -516,17 +516,20 @@ CONTAINS
 
          IF (hu <= hroof+1) THEN
             hu_ = hroof + 1.
-            write(6,*) 'Warning: the obs height of u less than htop+1, set it to hroof+1.'
+            IF (taux == spval) & ! only print warning for the firt time-step
+               write(6,*) 'Warning: the obs height of u less than htop+1, set it to hroof+1.'
          ENDIF
 
          IF (ht <= hroof+1) THEN
             ht_ = hroof + 1.
-            write(6,*) 'Warning: the obs height of t less than htop+1, set it to hroof+1.'
+            IF (taux == spval) & ! only print warning for the firt time-step
+               write(6,*) 'Warning: the obs height of t less than htop+1, set it to hroof+1.'
          ENDIF
 
          IF (hq <= hroof+1) THEN
             hq_ = hroof + 1.
-            write(6,*) 'Warning: the obs height of q less than htop+1, set it to hroof+1.'
+            IF (taux == spval) & ! only print warning for the firt time-step
+               write(6,*) 'Warning: the obs height of q less than htop+1, set it to hroof+1.'
          ENDIF
 
       ELSE ! relative height


### PR DESCRIPTION
than htop+1m.